### PR TITLE
Irb api endpoints #273

### DIFF
--- a/migrations/versions/119c1269ee7c_.py
+++ b/migrations/versions/119c1269ee7c_.py
@@ -30,5 +30,4 @@ def upgrade():
 
 def downgrade():
     op.drop_table('irb_status')
-    # op.drop_column('study', 'Q_COMPLETE')
     op.add_column('study', sa.Column('Q_COMPLETE', sa.Boolean(), nullable=True))

--- a/migrations/versions/119c1269ee7c_.py
+++ b/migrations/versions/119c1269ee7c_.py
@@ -1,0 +1,34 @@
+"""empty message
+
+Revision ID: 119c1269ee7c
+Revises: 93a1e2ce38dc
+Create Date: 2021-03-31 12:30:19.645458
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '119c1269ee7c'
+down_revision = '93a1e2ce38dc'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column('study', 'Q_COMPLETE')
+    op.create_table('irb_status',
+    sa.Column('STUDYID', sa.Integer(), nullable=False),
+    sa.Column('STATUS', sa.String(), nullable=False, default=''),
+    sa.Column('DETAIL', sa.String(), nullable=False, default=''),
+    sa.ForeignKeyConstraint(['STUDYID'], ['study.STUDYID'],),
+    sa.PrimaryKeyConstraint('STUDYID')
+    )
+
+
+
+def downgrade():
+    op.drop_table('irb_status')
+    # op.drop_column('study', 'Q_COMPLETE')
+    op.add_column('study', sa.Column('Q_COMPLETE', sa.Boolean(), nullable=True))

--- a/pb/api.yml
+++ b/pb/api.yml
@@ -133,6 +133,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/StudyDetail"
+  /check_study/{studyid}:
+    parameters:
+      - name: studyid
+        in: path
+        required: true
+        description: The id of the study.
+        schema:
+          type: integer
+          format: int32
+    get:
+      tags:
+      - CR-Connect
+      operationId: pb.check_study
+      summary: IRB Status about a particular study.
+      responses:
+        200:
+          description: Details about the protocol
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StudyDetail"
 components:
   schemas:
     Study:

--- a/pb/api.yml
+++ b/pb/api.yml
@@ -177,11 +177,6 @@ components:
           format: string
           example: jfg6n
           description: The UVA Id of of the principle investigator for the study.
-        Q_COMPLETE:
-          type: select
-          format: string
-          example: No Error
-          description: Study Status
         DATE_MODIFIED:
           type: string
           format: date_time
@@ -385,7 +380,7 @@ components:
           example: true
           description: Will this study be monitored by a Data and Safety Monitoring Board?
         DSMB_FREQUENCY:
-          type: String
+          type: string
           example: A lot
           description: UNDOCUMENTED.
         IS_DB:

--- a/pb/api.yml
+++ b/pb/api.yml
@@ -153,7 +153,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StudyDetail"
+                $ref: "#/components/schemas/IRBStatus"
 components:
   schemas:
     Study:
@@ -178,10 +178,10 @@ components:
           example: jfg6n
           description: The UVA Id of of the principle investigator for the study.
         Q_COMPLETE:
-          type: number
-          enum: [0,1]
-          example: 0
-          description: If 1, then this study is complete in the Protocol Builder, and is ready for processing by CR Connect.
+          type: select
+          format: string
+          example: No Error
+          description: Study Status
         DATE_MODIFIED:
           type: string
           format: date_time
@@ -254,6 +254,21 @@ components:
           type: string
           example: Principal Investigator
           description: A human readable descriptive string of the INVESTIGATORTYPE.
+    IRBStatus:
+      type: object
+      properties:
+        STUDYID:
+          type: number
+          example: 12345
+          description: The study id from the Protocol Builder
+        STATUS:
+          type: string
+          example: No Error
+          description: The study status
+        DETAIL:
+          type: string
+          example: Passed Validation
+          description: Detail about the study status
     StudyDetail:
       type: object
       properties:

--- a/pb/forms.py
+++ b/pb/forms.py
@@ -3,7 +3,7 @@ from flask_wtf import FlaskForm
 from wtforms import SelectMultipleField, StringField, BooleanField, SelectField, validators, HiddenField
 from wtforms_alchemy import ModelForm
 
-from pb.models import RequiredDocument, Investigator, StudyDetails
+from pb.models import RequiredDocument, Investigator, StudyDetails, IRBStatus
 
 
 class StudyForm(FlaskForm):
@@ -14,8 +14,8 @@ class StudyForm(FlaskForm):
                                        render_kw={'class': 'multi'},
                                        choices=[(rd.AUXDOCID, rd.AUXDOC) for rd in RequiredDocument.all()])
     HSRNUMBER = StringField('HSR Number')
-    Q_COMPLETE = BooleanField('Complete in Protocol Builder?', default='checked',
-                              false_values=(False, 'false', 0, '0'))
+    Q_COMPLETE = SelectField("IRBStatus",
+                             choices=[((q.STATUS, q.DETAIL), q.DETAIL) for q in IRBStatus.all()])
 
 
 class InvestigatorForm(FlaskForm):

--- a/pb/models.py
+++ b/pb/models.py
@@ -79,7 +79,7 @@ class StudySchema(ma.Schema):
     class Meta:
         # Fields to expose
         fields = ("STUDYID", "HSRNUMBER", "TITLE", "NETBADGEID",
-                  "Q_COMPLETE", "DATE_MODIFIED")
+                  "DATE_MODIFIED")
 
 
 class Investigator(db.Model):

--- a/pb/models.py
+++ b/pb/models.py
@@ -67,8 +67,8 @@ class Study(db.Model):
     HSRNUMBER = db.Column(db.String())
     TITLE = db.Column(db.Text(), nullable=False)
     NETBADGEID = db.Column(db.String(), nullable=False)
-    Q_COMPLETE = db.Column(db.Boolean, nullable=True)
     DATE_MODIFIED = db.Column(db.DateTime(timezone=True), default=func.now())
+    Q_COMPLETE = db.relationship("IRBStatus", backref="study", lazy='dynamic')
     requirements = db.relationship("RequiredDocument", backref="study", lazy='dynamic')
     investigators = db.relationship("Investigator", backref="study", lazy='dynamic')
     study_details = db.relationship("StudyDetails", uselist=False, backref="study")
@@ -161,6 +161,24 @@ class RequiredDocument(db.Model):
 class RequiredDocumentSchema(ma.Schema):
     class Meta:
         fields = ("AUXDOCID", "AUXDOC")
+
+
+class IRBStatus(db.Model):
+    STUDYID = db.Column(db.Integer, db.ForeignKey('study.STUDYID'), primary_key=True)
+    STATUS = db.Column(db.String(), nullable=False, default="")
+    DETAIL = db.Column(db.String(), nullable=False, default="")
+
+    @staticmethod
+    def all():
+        status = [IRBStatus(STATUS="Error", DETAIL="Study ID does not exist."),
+                  IRBStatus(STATUS="Error", DETAIL="General study errors. UVA Study Tracking Number is missing or not formatted correctly."),
+                  IRBStatus(STATUS="No Error", DETAIL="Passed validation.")]
+        return status
+
+
+class IRBStatusSchema(ma.Schema):
+    class Meta:
+        fields = ("STATUS", "DETAIL")
 
 
 class StudyDetails(db.Model):

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -57,6 +57,8 @@ class Sanity_Check_Test(unittest.TestCase):
         for r in form.requirements:
             form.data['requirements'].append(r.data)
 
+        form.Q_COMPLETE.data = "('No Error', 'Passed validation.')"
+
         r = self.app.post('/new_study', data=form.data, follow_redirects=False)
         assert r.status_code == 302
         added_study = Study.query.filter(Study.TITLE == study_title).first()
@@ -79,6 +81,7 @@ class Sanity_Check_Test(unittest.TestCase):
 
         for r in form_2.requirements:
             form_2.data['requirements'].append(r.data)
+        form_2.Q_COMPLETE.data = "('No Error', 'Passed validation.')"
 
         r_2 = self.app.post('/study/%i' % added_study.STUDYID, data=form_2.data, follow_redirects=False)
         assert r_2.status_code == 302


### PR DESCRIPTION
***This PR needs to be coordinated with #283 because of removing Q_COMPLETE as a column in PB Mock study table***

This PR modifies the new/edit Study form in PB Mock.
The `Complete in Protocol Builder` boolean has changed to a pulldown selector 

The `Q_COMPLETE` column in the study table was removed and a relationship was added to new irb_status table
Added a new relationship table `irb_status`

Added code to seed the form with correctly formatted data.
Added code to get data from form and format correctly for DB

Added an API endpoint `/check_study/{studyid}` to access this new information

Added migration script for DB changes