### PR TITLE
Persist selected user #319

### DIFF
--- a/migrations/versions/6c34576847ab_.py
+++ b/migrations/versions/6c34576847ab_.py
@@ -1,0 +1,28 @@
+"""empty message
+
+Revision ID: 6c34576847ab
+Revises: c14ddab2e6ca
+Create Date: 2021-05-11 11:10:14.725089
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6c34576847ab'
+down_revision = 'c14ddab2e6ca'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('selected_user',
+    sa.Column('user_id', sa.String(), nullable=False),
+    sa.Column('selected_user', sa.String(), nullable=True),
+    sa.PrimaryKeyConstraint('user_id')
+    )
+
+
+def downgrade():
+    op.drop_table('selected_user')

--- a/pb/models.py
+++ b/pb/models.py
@@ -281,9 +281,19 @@ class StudyDetails(db.Model):
     REVIEWTYPENAME = db.Column(db.String, nullable=True)
 
 
-
 class StudyDetailsSchema(ma.SQLAlchemyAutoSchema):
     class Meta:
         model = StudyDetails
         load_instance = True
         include_relationships = False
+
+
+class SelectedUser(db.Model):
+    user_id = db.Column(db.String(), primary_key=True)
+    selected_user = db.Column(db.String(), nullable=True)
+
+
+class SelectedUserSchema(ma.Schema):
+    class Meta:
+        fields = ("user_id", "selected_user")
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
     <a class="btn btn-primary" href="{{ url_for('.new_study') }}"> New Study </a>
 </p>
 <p>
-    <label>User Studies</label>
+    <label>Only Show Studies for: </label>
     <select name="uva_id" id="uva_id" onchange="selectStudies()">
         <option value="">Select User</option>
         <option value="all">All Users</option>
@@ -58,11 +58,7 @@
 <script>
     function selectStudies() {
         let uva_id = document.getElementById('uva_id').value;
-        if (uva_id == 'all') {
-            window.location.href = "{{base_href}}/";
-        } else {
-            window.location.href = "{{base_href}}/user_studies/" + uva_id;
-        }
+        window.location.href = "{{base_href}}/user_studies/" + uva_id;
     }
 </script>
 </body>

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -205,7 +205,7 @@ class Sanity_Check_Test(unittest.TestCase):
             if header[0] == 'Location':
                 self.assertIn('user_studies', header[1])
         studies2 = self.app.get(f'/user_studies/')
-        self.assertEqual('302 FOUND', studies2.status)
+        self.assertEqual('200 OK', studies2.status)
         for header in studies2.headers:
             if header[0] == 'Location':
                 self.assertNotIn('user_studies', header[1])


### PR DESCRIPTION
PB Mock grows by the week...

*** This PR includes a migration ***

We now remember the `selected_user` when loading the Protocol Builder Mock main page, and use selected_user to filter the list of studies.

We added a `selected_user` table to achieve this.
- It has 2 columns; user_id and selected_user.
- Both columns are strings
- user_id is primary_key

We modified the routes `/` and `/user_studies`
The / route now redirects to the /user_studies route

We added 2 methods to grab Uid from header; _is_production, and _get_request_uid
We added 3 methods to manage the selected_user process; get_current_user, get_selected_user, and update_selected_user
