### PR TITLE
Changed radiation material document name

### DIFF
--- a/pb/models.py
+++ b/pb/models.py
@@ -295,7 +295,7 @@ class RequiredDocument(db.Model):
                 RequiredDocument(SS_AUXILIARY_DOC_TYPE_ID=58, AUXILIARY_DOC="FDA Letter granting IND/IDE# or exemption"),
                 RequiredDocument(SS_AUXILIARY_DOC_TYPE_ID=59, AUXILIARY_DOC="SOM CTO Review for Gene Therapy/Transfer Study"),
                 RequiredDocument(SS_AUXILIARY_DOC_TYPE_ID=60, AUXILIARY_DOC="Recruitment Material"),
-                RequiredDocument(SS_AUXILIARY_DOC_TYPE_ID=61, AUXILIARY_DOC="Radioactive Material Use Approval")]
+                RequiredDocument(SS_AUXILIARY_DOC_TYPE_ID=61, AUXILIARY_DOC="Radiopharmaceuticals Use Approval")]
         return docs
 
 


### PR DESCRIPTION
The name of the "Radioactive Material Use Approval” was changed to “Radiopharmaceuticals Use Approval” due to an IRB name change.